### PR TITLE
Suggest talking about "people" rather than "users"

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -127,3 +127,6 @@ See also:
 * Avoid racist metaphors,
   including anything that might be interpreted as a reference to skin colors
   or allusions to racialized historical events.
+* Talk about "people" rather than "users" when that's unambiguous.
+  When talking about the people using a particular system or program,
+  it's fine to talk about "that system's users".

--- a/style-guide.md
+++ b/style-guide.md
@@ -128,5 +128,5 @@ See also:
   including anything that might be interpreted as a reference to skin colors
   or allusions to racialized historical events.
 * Talk about "people" rather than "users" when that's unambiguous.
-  When talking about the people using a particular system or program,
+  When talking about the people using a particular system,
   it's fine to talk about "that system's users".


### PR DESCRIPTION
This is a guideline we tried to follow in the Privacy Principles, and I think it's worth elevating to the style guide. You can't always follow it--sometimes you need to distinguish the people who are authors from the people who are [end-users](https://www.rfc-editor.org/rfc/rfc8890.html)--but it's worth striving for.